### PR TITLE
Add support for defaults and make release actually release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
 
       - deploy:
           name: Release and push
-          command: bundle exec rake install
+          command: bundle exec rake release
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+2023-05-04: Version 1.0.0
+- added support for default values:
+  - renamed `tlv_new` to `tlv_init` (leaving `tlv_new` as an alias)
+  - added new instance methods: `tlv_default`, `tlv_set_default`
+  - updated docs to explain how defaults are cross-threads
+- updated the README.md

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    thread_local_var_accessors (0.1.2)
+    thread_local_var_accessors (1.0.0)
       concurrent-ruby
 
 GEM
@@ -87,4 +87,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.4.6
+   2.4.12

--- a/README.md
+++ b/README.md
@@ -49,12 +49,22 @@ becomes very simple:
     timeout  # fetches the current TLV value, unique to each thread
     ...
     self.timeout = 0.5  # stores the TLV value just for this thread
+    
+The `tlv_init` method creates a _new_ TLVar and sets its default value.
+
+Note that the default value is used when any thread evaluates the instance 
+variable and there has been no thread-specific value assignment.
+
+The TLV default value is used across *all* threads.
+
+    tlv_init(:timeout, _default_)
+    tlv_init(:timeout) { _default_ }
 
 Alternative ways to initialize:
 
     tlv_set(:timeout, 0)
 
-    tlv_set(:timeout) # ensure that @timeout is initialized to an [TLV](TLV)
+    tlv_set(:timeout) # ensure that @timeout is initialized to an TLV
     @timeout.value = 0
 
 The following methods are used within the above reader, writer, accessor

--- a/lib/thread_local_var_accessors/version.rb
+++ b/lib/thread_local_var_accessors/version.rb
@@ -1,3 +1,3 @@
 module ThreadLocalVarAccessors
-  VERSION = '0.1.2'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
This PR adds support for default values to TLV accessors.

The PR was motivated by a client of this gem dealing with multiple threads and wanting to be able to have a non-nil default applied across all the threads until a specific value is assigned within each thread.

2023-05-04: Version 1.0.0

- added support for default values:
  - renamed `tlv_new` to `tlv_init` (leaving `tlv_new` as an alias)
  - added new instance methods: `tlv_default`, `tlv_set_default`
  - updated docs to explain how defaults are cross-threads
- updated the README.md
